### PR TITLE
Document root support

### DIFF
--- a/settings.cpp
+++ b/settings.cpp
@@ -173,6 +173,7 @@ void applyConfigOverride(const settings::CliArg &arg) {
     map<string, vector<string>> cliMappings = {
         // Top level
         {"--mode", {"/defaultMode", "string"}},
+		{"--document-root", {"/documentRoot", "string"}},
         {"--url", {"/url", "string"}},
         {"--port", {"/port", "int"}},
         {"--logging-enabled", {"/logging/enabled", "bool"}},

--- a/settings.cpp
+++ b/settings.cpp
@@ -173,7 +173,7 @@ void applyConfigOverride(const settings::CliArg &arg) {
     map<string, vector<string>> cliMappings = {
         // Top level
         {"--mode", {"/defaultMode", "string"}},
-		{"--document-root", {"/documentRoot", "string"}},
+        {"--document-root", {"/documentRoot", "string"}},
         {"--url", {"/url", "string"}},
         {"--port", {"/port", "int"}},
         {"--logging-enabled", {"/logging/enabled", "bool"}},


### PR DESCRIPTION
Added document-root to the cliMappings in settings.cpp allowing for the documentRoot to be overridden by the CLI.